### PR TITLE
added filter on discount calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ If you want to help us work around this problem, please send an [Pull Request on
 ## Screenshots ##
 
 ### 1. Settings page. ###
-![1. Settings page.](http://ps.w.org/woocommerce-discounts-per-payment-method/assets/screenshot-1.png)
+![1.Settings page.](https://ps.w.org/woocommerce-payment-discounts/assets/screenshot-1.png)
 
 ### 2. Plugin in action on checkout page. ###
-![2. Plugin in action on checkout page.](http://ps.w.org/woocommerce-discounts-per-payment-method/assets/screenshot-2.png)
+![2. Plugin in action on checkout page.](https://ps.w.org/woocommerce-payment-discounts/assets/screenshot-2.png)
 
 
 ## Changelog ##

--- a/includes/class-wc-payment-discounts-add-discount.php
+++ b/includes/class-wc-payment-discounts-add-discount.php
@@ -47,7 +47,7 @@ class WC_Payment_Discounts_Add_Discount {
 			$amount = ( $subtotal / 100 ) * str_replace( '%', '', $amount );
 		}
 
-		return apply_filters( 'wc_payment_discounts_amount', $amount ); $amount;
+		return apply_filters( 'wc_payment_discounts_amount', $amount );
 	}
 
 	/**

--- a/includes/class-wc-payment-discounts-add-discount.php
+++ b/includes/class-wc-payment-discounts-add-discount.php
@@ -92,7 +92,8 @@ class WC_Payment_Discounts_Add_Discount {
 				$value = wc_price( $amount );
 			}
 
-			$title .= ' <small>(' . sprintf( __( '%s off', 'woocommerce-payment-discounts' ), $value ) . ')</small>';
+			$title_suffix = ' <small>(' . sprintf( __( '%s off', 'woocommerce-payment-discounts' ), $value ) . ')</small>';
+			$title .= apply_filters('wc_payment_discounts_method_suffix', $title_suffix, $value);
 		}
 
 		return $title;

--- a/includes/class-wc-payment-discounts-add-discount.php
+++ b/includes/class-wc-payment-discounts-add-discount.php
@@ -47,7 +47,7 @@ class WC_Payment_Discounts_Add_Discount {
 			$amount = ( $subtotal / 100 ) * str_replace( '%', '', $amount );
 		}
 
-		return $amount;
+		return apply_filters( 'wcpd-amount', $amount ); $amount;
 	}
 
 	/**

--- a/includes/class-wc-payment-discounts-add-discount.php
+++ b/includes/class-wc-payment-discounts-add-discount.php
@@ -47,7 +47,7 @@ class WC_Payment_Discounts_Add_Discount {
 			$amount = ( $subtotal / 100 ) * str_replace( '%', '', $amount );
 		}
 
-		return apply_filters( 'wcpd-amount', $amount ); $amount;
+		return apply_filters( 'wc_payment_discounts_amount', $amount ); $amount;
 	}
 
 	/**

--- a/includes/class-wc-payment-discounts-add-discount.php
+++ b/includes/class-wc-payment-discounts-add-discount.php
@@ -60,10 +60,12 @@ class WC_Payment_Discounts_Add_Discount {
 	 */
 	protected function discount_name( $amount, $gateway ) {
 		if ( strstr( $amount, '%' ) ) {
-			return sprintf( __( 'Discount for %s (%s off)', 'woocommerce-payment-discounts' ), esc_attr( $gateway->title ), $amount );
+			$discount_name = sprintf( __( 'Discount for %s (%s off)', 'woocommerce-payment-discounts' ), esc_attr( $gateway->title ), $amount );
+			return apply_filters( 'wc_payment_discounts_discount_name_percent', $discount_name, $amount, $gateway);
 		}
 
-		return sprintf( __( 'Discount for %s', 'woocommerce-payment-discounts' ), esc_attr( $gateway->title ) );
+		$discount_name =  sprintf( __( 'Discount for %s', 'woocommerce-payment-discounts' ), esc_attr( $gateway->title ) );
+		return apply_filters( 'wc_payment_discounts_discount_name', $discount_name, $amount, $gateway );
 	}
 
 	/**


### PR DESCRIPTION
Reason for this is for example "price cosmetics". Instead of a discount of $14.48 we would like to have $14.50. Who knows what people want to do with it...

example for a user:
function round_payment_discount( $amount ) {
    $amount = round($amount * 2, 0) / 2;
    return $amount;
}
add_filter( 'wcpd-amount', 'round_payment_discount', 10, 3 );