### PR TITLE
Calculate totals after remove a coupon

### DIFF
--- a/includes/class-wc-payment-discounts-apply-discount.php
+++ b/includes/class-wc-payment-discounts-apply-discount.php
@@ -86,6 +86,7 @@ class WC_Payment_Discounts_Apply_Discount {
 		foreach ( $cart->get_applied_coupons() as $code ) {
 			if ( 'wcpd_' === substr( $code, 0, 5 ) && $code !== $skip ) {
 				$cart->remove_coupon( $code );
+				$cart->calculate_totals();
 				$removed = true;
 			}
 		}


### PR DESCRIPTION
Ref.: https://github.com/claudiosanches/woocommerce-payment-discounts/issues/31

After switch to a payment method without discount the coupon is removed but the cart total still the same.

In my opinion it should be a WC responsibility as a callback after remove a coupon like when a product or coupon is added, [see here](https://github.com/woocommerce/woocommerce/blob/f57dee51572f048c308a8cf15025c84d8ba7e119/includes/class-wc-cart.php#L111-L112).